### PR TITLE
Update readme to reflect imageio version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ When it comes to object detection, popular detection frameworks are
  ## Dependencies
   * opencv
   * numpy
-  * imageio
+  * imageio ( version 2.4.1 )
   
 `pip install numpy opencv-python imageio`
+`sudo pip3 install imageio==2.4.1`
+
 
 **Note: Python 2.x is not supported**
 


### PR DESCRIPTION
Running project by default will result in "RuntimeError: imageio.ffmpeg.download() has been deprecated. Use 'pip install imageio-ffmpeg' instead.' "

To fix need to hardcode imageio to 2.4.1